### PR TITLE
Add check and error warning if Rval is a null response.

### DIFF
--- a/src/GAMClient.ts
+++ b/src/GAMClient.ts
@@ -57,8 +57,7 @@ class GAMClient {
               res = await promiseFromCallback((cb) => client[method](dto, cb));
             }
 
-            return Array.isArray(res) ? res[0].rval : res.rval;
-
+            return Array.isArray(res) ? !res[0] ? new Error("Got no rval from GAM API, check if values sent are correct") : res[0].rval : res.rval;
           };
         } else {
           return target[method];


### PR DESCRIPTION
Before if we got a rval that is null the application will crash, instead of crashing, return a error that we get a null response from GAM API and inform the user to check if they are using the right method / data.